### PR TITLE
feat: allow cooperative request interception

### DIFF
--- a/src/browser/page.js
+++ b/src/browser/page.js
@@ -31,7 +31,7 @@ async function BlockRequests(page, domains) {
       log.debug('Request blocked', { url: request.url() });
       request.abort();
     } else {
-      request.continue().catch((err) => {
+      request.continue(request.continueRequestOverrides(), 0).catch((err) => {
         log.error(
           `Could not continue request(${request.method()} ${request.url()}): `,
           err


### PR DESCRIPTION
https://pptr.dev/guides/request-interception#cooperative-request-continuation

https://pptr.dev/guides/request-interception#upgrading-to-cooperative-intercept-mode-for-package-maintainers

Right now the "request blocker" interceptor doesn't allow any other interception to exist, because it operates in "legacy mode", when one and only one interceptor can process a request. It is problematic, because users cannot use additional custom written interceptors. 

Setting priority to 0 for "continue" solves this problem and allows additional interceptors